### PR TITLE
Fix SQL syntax error in migration patch

### DIFF
--- a/utm_shortener/patches/fix_short_url_generation.py
+++ b/utm_shortener/patches/fix_short_url_generation.py
@@ -3,11 +3,12 @@ import frappe
 def execute():
     """Fix existing Short URLs that have null short_url field"""
     
-    # Get all Short URLs with null short_url
-    short_urls = frappe.get_all("Short URL", 
-        filters={"short_url": ["is", "null"]},
-        fields=["name", "short_code"]
-    )
+    # Get all Short URLs where short_url is null or empty
+    short_urls = frappe.db.sql("""
+        SELECT name, short_code 
+        FROM `tabShort URL` 
+        WHERE short_url IS NULL OR short_url = ''
+    """, as_dict=True)
     
     if short_urls:
         print(f"Found {len(short_urls)} Short URLs to fix")


### PR DESCRIPTION
## Fix SQL Syntax Error in Migration Patch

This PR fixes the SQL syntax error that occurs during migration:
```
Syntax error in query:
select `name`, `short_code`
from `tabShort URL`
where coalesce(`tabShort URL`.`short_url`, '') is ''
```

### Issue
The `frappe.get_all()` method with filter `["is", "null"]` was generating incorrect SQL syntax.

### Solution
Changed to use direct SQL query with proper NULL checking:
```python
# Old (causing error):
frappe.get_all("Short URL", 
    filters={"short_url": ["is", "null"]},
    fields=["name", "short_code"]
)

# New (fixed):
frappe.db.sql("""
    SELECT name, short_code 
    FROM `tabShort URL` 
    WHERE short_url IS NULL OR short_url = ''
""", as_dict=True)
```

### Testing
After merging, run migration again:
```bash
bench --site meta-app.frappe.cloud migrate
```